### PR TITLE
Remove org dependency

### DIFF
--- a/org-projectile.el
+++ b/org-projectile.el
@@ -6,7 +6,7 @@
 ;; Keywords: org projectile todo
 ;; URL: https://github.com/IvanMalison/org-projectile
 ;; Version: 0.0.1
-;; Package-Requires: ((projectile "0.11.0") (org "8.2.4"))
+;; Package-Requires: ((projectile "0.11.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This dependency installs the `org` package even if I already have the `org-plus-contrib` one.

I don't know if there's a way to depends on one or the other but I think most packages don't list `org` as a dependency. See https://github.com/nsf/gocode/blob/71ddfa9f5e27550498120f39b34bb79f8cfcc7fe/emacs-company/company-go.el#L7
