### PR TITLE
Use project name for current project category

### DIFF
--- a/org-project-capture-backend.el
+++ b/org-project-capture-backend.el
@@ -94,7 +94,7 @@
 (cl-defmethod org-project-capture-current-project
   ((_backend org-project-capture-project-backend))
   "Return the current project using `project-current'."
-  (project-current))
+  (project-name (project-current)))
 
 (provide 'org-project-capture-backend)
 ;;; org-project-capture-backend.el ends here

--- a/org-project-capture-backend.el
+++ b/org-project-capture-backend.el
@@ -83,7 +83,7 @@
 (cl-defmethod org-project-capture-project-root-of-filepath
   ((_ org-project-capture-project-backend) filepath)
   "Return the project root for FILEPATH using `project-current'."
-  (cdr (project-current nil filepath)))
+  (project-root (project-current nil filepath)))
 
 (cl-defmethod org-project-capture-switch-to-project
   ((_ org-project-capture-project-backend) directory)

--- a/org-project-capture-backend.el
+++ b/org-project-capture-backend.el
@@ -83,7 +83,8 @@
 (cl-defmethod org-project-capture-project-root-of-filepath
   ((_ org-project-capture-project-backend) filepath)
   "Return the project root for FILEPATH using `project-current'."
-  (project-root (project-current nil filepath)))
+  (when-let ((project (project-current nil filepath)))
+    (project-root project)))
 
 (cl-defmethod org-project-capture-switch-to-project
   ((_ org-project-capture-project-backend) directory)
@@ -94,7 +95,8 @@
 (cl-defmethod org-project-capture-current-project
   ((_backend org-project-capture-project-backend))
   "Return the current project using `project-current'."
-  (project-name (project-current)))
+  (when-let ((project (project-current)))
+    (project-name project)))
 
 (provide 'org-project-capture-backend)
 ;;; org-project-capture-backend.el ends here

--- a/test/org-project-capture-backend-test.el
+++ b/test/org-project-capture-backend-test.el
@@ -97,7 +97,11 @@
     (cl-letf (((symbol-function 'project-current)
                (lambda (_maybe-prompt dir)
                  (when (string-prefix-p "/home/user/myproj" dir)
-                   (cons 'vc "/home/user/myproj")))))
+                   'fake-project)))
+              ((symbol-function 'project-root)
+               (lambda (project)
+                 (should (eq project 'fake-project))
+                 "/home/user/myproj")))
       (should (string-equal
                (org-project-capture-category-from-file
                 backend "/home/user/myproj/src/file.el")
@@ -110,6 +114,26 @@
                (lambda (_maybe-prompt _dir) nil)))
       (should (null (org-project-capture-category-from-file
                      backend "/tmp/random-file.txt"))))))
+
+(ert-deftest test-current-project ()
+  "Test getting the current project name."
+  (let ((backend (make-instance 'org-project-capture-project-backend)))
+    (cl-letf (((symbol-function 'project-current)
+               (lambda (&optional _maybe-prompt _dir) 'fake-project))
+              ((symbol-function 'project-name)
+               (lambda (project)
+                 (should (eq project 'fake-project))
+                 "myproj")))
+      (should (string-equal
+               (org-project-capture-current-project backend)
+               "myproj")))))
+
+(ert-deftest test-current-project-not-in-project ()
+  "Test current-project when not in a project."
+  (let ((backend (make-instance 'org-project-capture-project-backend)))
+    (cl-letf (((symbol-function 'project-current)
+               (lambda (&optional _maybe-prompt _dir) nil)))
+      (should (null (org-project-capture-current-project backend))))))
 
 ;; Tests for get-all-categories
 


### PR DESCRIPTION
Hello. I tried setting up `org-project-capture` with the following setup:

```emacs-lisp
(require 'org-project-capture)
(setq org-project-capture-default-backend (make-instance 'org-project-capture-project-backend))
(org-project-capture-per-project)
```

I kept running into the `Wrong type argument: stringp, nil` error when trying to capture a new task via `org-project-capture-capture-for-current-project` with the following trace:

```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  org-project-capture-get-project-todo-file(nil)
  #f(compiled-function (s category) "Get the capture file for CATEGORY using per-project strategy S." #<bytecode -0x7fd5e0dc3a5e92d>)(#<org-project-capture-per-project-strategy org-project-capture-per-project-strategy-1034737ed64b> (vc Git "~/path/to/project/"))
  apply(#f(compiled-function (s category) "Get the capture file for CATEGORY using per-project strategy S." #<bytecode -0x7fd5e0dc3a5e92d>) #<org-project-capture-per-project-strategy org-project-capture-per-project-strategy-1034737ed64b> (vc Git "~/path/to/project/"))
  occ-get-capture-file(#<org-project-capture-per-project-strategy org-project-capture-per-project-strategy-1034737ed64b> (vc Git "~/path/to/project/"))
  #f(compiled-function (strategy context) "Get capture marker for CONTEXT using per-project STRATEGY." #<bytecode 0x78a4fe047a3c18f>)(#<org-project-capture-per-project-strategy org-project-capture-per-project-strategy-1034737ed64b> #<occ-context occ-context-103473556f26>)
  apply(#f(compiled-function (strategy context) "Get capture marker for CONTEXT using per-project STRATEGY." #<bytecode 0x78a4fe047a3c18f>) #<org-project-capture-per-project-strategy org-project-capture-per-project-strategy-1034737ed64b> #<occ-context occ-context-103473556f26>)
  occ-get-capture-marker(#<org-project-capture-per-project-strategy org-project-capture-per-project-strategy-1034737ed64b> #<occ-context occ-context-103473556f26>)
  #f(compiled-function (context) "Get the capture marker for CONTEXT by delegating to its strategy." #<bytecode 0x147e1d1072bf1ba0>)(#<occ-context occ-context-103473556f26>)
  apply(#f(compiled-function (context) "Get the capture marker for CONTEXT by delegating to its strategy." #<bytecode 0x147e1d1072bf1ba0>) #<occ-context occ-context-103473556f26> nil)
  occ-get-capture-marker(#<occ-context occ-context-103473556f26>)
  #f(compiled-function (context) "Move to the capture location for CONTEXT in the current window." #<bytecode 0x1551776f29256926>)(#<occ-context occ-context-103473556f26>)
  apply(#f(compiled-function (context) "Move to the capture location for CONTEXT in the current window." #<bytecode 0x1551776f29256926>) #<occ-context occ-context-103473556f26> nil)
  occ-capture-edit-at-marker(#<occ-context occ-context-103473556f26>)
  #f(compiled-function () #<bytecode 0x1d7246ba7737ed87>)()
  org-capture-set-target-location(nil)
  org-capture(nil "p")
  #f(compiled-function (context) "Initiate an `org-capture' using CONTEXT to determine the target." #<bytecode -0x199990a6abc17586>)(#<occ-context occ-context-103473556f26>)
  apply(#f(compiled-function (context) "Initiate an `org-capture' using CONTEXT to determine the target." #<bytecode -0x199990a6abc17586>) #<occ-context occ-context-103473556f26> nil)
  occ-capture(#<occ-context occ-context-103473556f26>)
  org-project-capture-capture-for-current-project()
  eval((org-project-capture-capture-for-current-project) t)
  #f(compiled-function () #<bytecode -0x8ac0d50fd3cb416>)()
  #f(compiled-function () #<bytecode -0x5db3e1955cb81d1>)()
  eval-expression((org-project-capture-capture-for-current-project) nil nil 127)
  funcall-interactively(eval-expression (org-project-capture-capture-for-current-project) nil nil 127)
  command-execute(eval-expression)
```

I traced it to the mismatch between what the `:category` on the `occ-context` names (in my case `(vc Git "~/path/to/project/")` and the keys that `(org-project-capture-build-category-to-project-path org-project-capture-strategy)` call produces (in this case just `project`).

I'm not sure if this is the right way to fix this, as I haven't used project.el nor `org-project-capture` before, but it certainly makes it capture tasks in the right file.